### PR TITLE
Get orphaned extension rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 .coverage
 doc/_build
+.idea

--- a/dwca/files.py
+++ b/dwca/files.py
@@ -69,6 +69,11 @@ class CSVDataFile(object):
 
         raise StopIteration
 
+    def get_coreid_index(self):
+        if not hasattr(self, '_coreid_index'):
+            self._coreid_index = self._build_coreid_index()
+        return self._coreid_index
+
     # Returns a index of the per core_id positions of Rows in the file:
     # {core_id1: []}
 

--- a/dwca/read.py
+++ b/dwca/read.py
@@ -135,6 +135,26 @@ class DwCAReader(object):
                     r[key] = self._parse_xml_included_file(os.path.join(SOURCE_METADATA_DIRECTORY, f))
         return r
 
+    def orphaned_extension_rows(self):
+        if (len(self._extensionfiles) > 0):
+
+            temp_ids = {}
+            for row in self:
+                temp_ids[row.id] = 1
+            ids = temp_ids.keys()
+
+            indexes = {}
+            for extension in self._extensionfiles:
+                coreid_index = extension.get_coreid_index().copy()
+                for id in ids:
+                    coreid_index.pop(id, None)
+                indexes[extension.file_descriptor.file_location] = coreid_index
+
+            return indexes
+
+        else:
+            return {}
+
     @property
     def use_extensions(self):
         """Return True if the Archive makes use of extensions."""


### PR DESCRIPTION
I need to do some validation on the archives I'm reading, and this includes checking if all extension rows have matching core rows. This PR adds a method `DwCAReader.orphaned_extension_rows()` which returns non-matching core IDs and orphaned extension row indices as follows:

```
{
    'extendedmeasurementorfact.txt': {
          u'Cruise68:Station593:EventSorbeSledge9887:Subsample16686_5': [11136],
          u'Cruise64:Station550:EventSorbeSledge9740:Subsample9878_4': [1413, 1414, 1415]
    },
    'occurrence.txt': {
        u'Cruise66:Station591:EventSorbeSledge9885:Subsample9959_2': [4928],
        u'Cruise66:Station589:EventSorbeSledge9883:Subsample9953_1': [4739],
        u'Cruise68:Station579:EventSorbeSledge9810:Subsample17412_3': [5977]
    }
}
```

There may be a more elegant implementation.