### PR TITLE
Pin the build backend so sdist filenames stay PEP 625 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+# Declaring the build backend makes builds reproducible: `python -m build` resolves these
+# requirements in an isolated environment instead of using whatever setuptools happens to be
+# first on PATH.
+#
+# The version floor is not arbitrary. setuptools 69.3 is where sdist filenames became
+# PEP 625 normalised ("python_dwca_reader-X.Y.Z.tar.gz" rather than "python-dwca-reader-..."),
+# and PyPI now rejects the old form outright. Building 0.17.0 with an older setuptools
+# produced an sdist the upload refused.
+#
+# Package metadata deliberately stays in setup.py for now; this file only pins how the build
+# happens, not what is built.
+[build-system]
+requires = ["setuptools>=69.3", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     license="BSD licence, see LICENCE.txt",
     description="A simple Python package to read Darwin Core Archive (DwC-A) files.",
     long_description=open("README.rst").read(),
+    long_description_content_type="text/x-rst",
     python_requires=">=3.8",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Building 0.17.0 produced `python-dwca-reader-0.17.0.tar.gz`, which PyPI rejects:

```
400 Filename 'python-dwca-reader-0.17.0.tar.gz' is invalid,
    should be 'python_dwca_reader-0.17.0.tar.gz'.
```

## Cause

PEP 625 requires sdist filenames to use the normalised project name. setuptools started
emitting that form in **69.3**, but `python setup.py sdist` builds with whatever setuptools
happens to be first on `PATH`. On the release machine that was 68.0.0, which predates the
change, so the sdist got the old dash form. (Wheels were unaffected - they have always used
the normalised name.)

## Fix

Declaring the build backend means `python -m build` resolves its own requirements in an
isolated environment rather than inheriting the caller's setuptools.

Verified rather than assumed: built the project from a virtualenv deliberately pinned to
`setuptools==68.0.0` - the exact failure condition - and the artifact is still named
`python_dwca_reader-0.17.0.tar.gz`, because isolation honours the floor declared here.

Checked the change is otherwise inert:

- the sdist's file list is identical to the one built before, apart from `pyproject.toml`
  itself now being included
- `Metadata-Version`, `Name`, `Version` and `Requires-Python` are unchanged
- `python -m pip install .` (what CI runs) still works and the installed package reads
  archives correctly
- the test suite is unchanged at 222 passing

Package metadata deliberately stays in `setup.py`. This only pins how the build happens, not
what is built - a PEP 621 migration is a separate change and not one to make immediately after
a release.

## Also

Sets `long_description_content_type="text/x-rst"`. `README.rst` is reStructuredText and that is
already the inferred default, so this changes nothing about the rendered page - it just silences
the warning twine prints on every upload. `twine check` now reports PASSED with no warnings.

## Not included

The `build/` directory left behind by `setup.py` shadows the PyPA `build` module, so
`python -m build` from a dirty working tree fails with a confusing "No module named build".
Worth knowing when releasing; not worth a code change here.
