### PR TITLE
Unpin the docs toolchain so Read the Docs can build again

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,7 +10,6 @@
 # serve to show the default.
 
 import sys, os
-import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -103,8 +102,8 @@ html_theme = "sphinx_rtd_theme"
 # documentation.
 # html_theme_options = {}
 
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# The theme is discovered through its entry point; sphinx_rtd_theme.get_html_theme_path()
+# was deprecated and setting html_theme_path is no longer needed.
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -125,7 +124,9 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# No custom static assets, and pointing at a directory that does not exist makes Sphinx
+# warn on every build.
+html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/doc_requirements.txt
+++ b/doc/doc_requirements.txt
@@ -1,24 +1,8 @@
-alabaster==0.7.12
-Babel==2.9.1
-certifi==2019.6.16
-chardet==3.0.4
-docutils==0.15.2
-idna==2.8
-imagesize==1.1.0
-Jinja2==2.11.3
-MarkupSafe==1.1.1
-packaging==19.2
-Pygments==2.7.4
-pyparsing==2.4.2
-pytz==2019.2
-requests==2.22.0
-six==1.12.0
-snowballstemmer==1.9.1
-Sphinx==2.2.0
-sphinx-rtd-theme==0.4.3
-sphinxcontrib-applehelp==1.0.1
-sphinxcontrib-devhelp==1.0.1
-sphinxcontrib-htmlhelp==1.0.2
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.2
-sphinxcontrib-serializinghtml==1.1.3
+# Only the direct dependencies are listed. This file used to pin every transitive
+# dependency at its 2019 version, which is what eventually broke the Read the Docs build:
+# Sphinx 2.2.0 imports pkg_resources, and setuptools removed it in 81.0, so the build died
+# with ModuleNotFoundError before it read a single page.
+#
+# Lower bounds only, so a routine dependency update cannot silently rot the docs again.
+Sphinx>=7
+sphinx-rtd-theme>=2

--- a/dwca/star_record.py
+++ b/dwca/star_record.py
@@ -6,7 +6,7 @@ import itertools
 class StarRecordIterator(object):
     """Object used to iterate over multiple DWCA-files joined on the coreid
 
-    :param files_to_join: a list of the `dwca.files.CSVDataFile`s we'd like to join.
+    :param files_to_join: a list of the :class:`dwca.files.CSVDataFile` objects to join.
         May or may not include the core file (the core is not treated in a special way)
     :param how: indicates the type of join.  "inner" and "outer" correspond vaguely to
         inner and full joins.  The outer join includes rows that don't match on all files,


### PR DESCRIPTION
The Read the Docs build fails before it reads a single page:

```
from pkg_resources import iter_entry_points
ModuleNotFoundError: No module named 'pkg_resources'
```

## Cause

`doc/doc_requirements.txt` pinned **Sphinx 2.2.0** along with its entire 2019 dependency
set. Sphinx 2.2.0 imports `pkg_resources`, which setuptools removed in **81.0**. Nothing in
the repository changed to cause this - the pins simply rotted until Read the Docs rebuilt the
environment, which the 0.17.0 release triggered.

Pinning every transitive dependency is what let it rot silently for six years, so this drops
to the two direct dependencies with lower bounds only.

## Also fixes the build warnings

The build emitted three, and one of them was introduced by this release:

- `dwca/star_record.py` - adding `dwca.star_record` to the API reference (new in 0.17.0)
  started rendering its docstring, which attached a trailing `s` directly to inline markup.
  That is invalid reStructuredText. Now a proper `:class:` cross-reference.
- `doc/conf.py` - `sphinx_rtd_theme.get_html_theme_path()` is deprecated; the theme is found
  through its entry point, so `html_theme_path` and the import go away.
- `doc/conf.py` - `html_static_path` pointed at `doc/_static`, which does not exist.

## Verification

Built with the exact command Read the Docs runs, in a virtualenv containing only
`doc_requirements.txt` and **without** the package installed, matching the RTD environment:

```
python -m sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
```

`build succeeded`, zero warnings. Resolved to Sphinx 9.0.4 and sphinx-rtd-theme 3.1.0.

Autodoc still picks up the API surface: `iter_terms` (9 mentions in `api.html`),
`StarRecordIterator`, `skip_metadata`, `get_corerow_by_position`, and no references to the
long-removed `get_row_by_index`. Test suite unchanged at 222 passing.

## One thing this does NOT fix

Read the Docs builds `stable` from the **latest tag**, which is `v0.17.0` and predates this
commit. Merging this repairs the `latest` build immediately, but `stable` will keep failing
until a tag exists that contains it. That needs either a 0.17.1 release or moving the tag -
a decision worth making deliberately, since `v0.17.0` currently matches exactly what is
published on PyPI.
